### PR TITLE
Relax version constraints for activesupport and activemodel

### DIFF
--- a/avetmiss_validations.gemspec
+++ b/avetmiss_validations.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'byebug', '~> 2.7'
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'coveralls'
-  s.add_dependency 'activesupport', '>= 3', '< 5'
-  s.add_dependency 'activemodel', '>= 3', '< 5'
+  s.add_dependency 'activesupport', '>= 3'
+  s.add_dependency 'activemodel', '>= 3'
   s.add_dependency 'avetmiss_data', '> 0'
 
   s.files        = `git ls-files`.split("\n")

--- a/lib/avetmiss_validations/version.rb
+++ b/lib/avetmiss_validations/version.rb
@@ -1,3 +1,3 @@
 module AvetmissValidations
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end


### PR DESCRIPTION
Relax the version constraints for activesupport and activemodel so that this gem can be used by a Rails 5 app.